### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/qubesmirror/check.py
+++ b/qubesmirror/check.py
@@ -122,4 +122,4 @@ async def main(args=None):
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

resolves: QubesOS/qubes-issues#10188